### PR TITLE
Preliminary player LOS

### DIFF
--- a/Bug/Assets/Framework/InternalCode/BugBaseTypes.cs
+++ b/Bug/Assets/Framework/InternalCode/BugBaseTypes.cs
@@ -26,6 +26,7 @@ namespace Bug
         Perception,
         Speed,
         Strength,
+        ViewDistance,
 
         FinalAttribute  //  Always add new attribs before this one!
     }
@@ -40,13 +41,61 @@ namespace Bug
             _go = anObj;
         }
 
+        public float this[EntityAttribute attr] 
+        {
+            get
+            {
+                float rtn = 0f;
+                if (_attrs.ContainsKey(attr))
+                {
+                    rtn = _attrs[attr];
+                }
+                return rtn;
+            }
+            set
+            {
+                _attrs[attr] = value;
+            }
+        }
+
+        public float DistanceTo(EntityBase aTarget)
+        {
+            float rtn = float.NaN;
+            if (aTarget != null)
+            {
+                if ((GO != null) && (aTarget.GO != null))
+                {
+                    rtn = Vector2.Distance(pos, aTarget.pos);
+                }
+            }
+            return rtn;
+        }
+
+        public Vector2 pos 
+        {
+            get
+            {
+                Vector2 rtn = new Vector2(0, 0);
+                if (GO != null)
+                {
+                    rtn.x = GO.transform.position.x;
+                    rtn.y = GO.transform.position.y;
+                }
+                return rtn;
+            }
+        }
+
         protected GameObject _go = null;
+        protected Dictionary<EntityAttribute, float> _attrs = new Dictionary<EntityAttribute, float>();
     }
 
     public class EntityMovable : EntityBase
     {
         public EntityMovable(GameObject anObj) : base(anObj)
         {
+            //  Set default attributes for this type of entity...
+            this[EntityAttribute.ViewDistance] = 10f;
+
         }
 
         public void SetDestination(Vector2 aLoc)

--- a/Bug/Assets/Framework/TestScripts/TestPlayerMovement.cs
+++ b/Bug/Assets/Framework/TestScripts/TestPlayerMovement.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -93,10 +94,47 @@ public class TestPlayerMovement : MonoBehaviour, IManagedInput
         }
     }
 
+    List<GameObject> restoreList = new List<GameObject>();
+
     // Update is called once per frame
     void Update()
     {
+        List<GameObject> visList = new List<GameObject>();
         Entities.Instance.ProcessAllMovement(Time.deltaTime);
+        int visCount = Entities.Instance.PlayerVisibleList(visList);
+        if (visCount > 0)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine($"Player visible from {visCount} objects:");
+            foreach (GameObject o in visList)
+            {
+                sb.AppendLine($"   Obj: {o.name}");
+                SpriteRenderer sr = o.GetComponent<SpriteRenderer>();
+                if (sr != null)
+                {
+                    sr.color = new Color(sr.color.r, sr.color.g, sr.color.b, 0.3f);
+                    if (!restoreList.Contains(o))
+                    {
+                        restoreList.Add(o);
+                    }
+                }
+            }
+            sb.AppendLine();
+            sb.AppendLine();
+            Debug.LogWarning(sb.ToString());
+        }
+        for (int i=restoreList.Count-1; i>=0; i--)
+        {
+            if (!visList.Contains(restoreList[i]))  //  Need to restore this sprite's color...
+            {
+                SpriteRenderer sr = restoreList[i].GetComponent<SpriteRenderer>();
+                if (sr != null)
+                {
+                    sr.color = new Color(sr.color.r, sr.color.g, sr.color.b, 1.0f);
+                }
+                restoreList.RemoveAt(i);
+            }
+        }
     }
 
     private void OnCollisionEnter2D(Collision2D collision)

--- a/Bug/ProjectSettings/ProjectVersion.txt
+++ b/Bug/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.17f1
-m_EditorVersionWithRevision: 2020.3.17f1 (a4537701e4ab)
+m_EditorVersion: 2020.3.22f1
+m_EditorVersionWithRevision: 2020.3.22f1 (e1a7f79fd887)


### PR DESCRIPTION
Early attempt at line-of-sight to player, this updates the player movement script to make any hosts that can "see" the player semi-transparent.

Also updated project back to 2020.3.22 (had previously been downgraded to .17)